### PR TITLE
Send the signal specified in the option in cleanup as well

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -26,11 +26,14 @@ sub start_server {
     };
     $opts->{interval} = 1
         if not defined $opts->{interval};
-    $opts->{signal_on_hup} ||= 'TERM';
-    # normalize to the one that can be passed to kill
-    $opts->{signal_on_hup} =~ tr/a-z/A-Z/;
-    $opts->{signal_on_hup} =~ s/^SIG//i;
-    
+    $opts->{signal_on_hup}  ||= 'TERM';
+    $opts->{signal_on_term} ||= 'TERM';
+    for ($opts->{signal_on_hup}, $opts->{signal_on_term}) {
+        # normalize to the one that can be passed to kill
+        tr/a-z/A-Z/;
+        s/^SIG//i;
+    }
+
     # prepare args
     my $ports = $opts->{port};
     my $paths = $opts->{path};
@@ -162,6 +165,7 @@ sub start_server {
         };
     
     # the main loop
+    my $term_signal;
     $current_worker = _start_worker($opts);
     $update_status->();
     while (1) {
@@ -192,6 +196,7 @@ sub start_server {
                 kill $opts->{signal_on_hup}, $_
                     for sort keys %old_workers;
             } else {
+                $term_signal = $signals_received[0] eq 'TERM' ? $opts->{signal_on_term} : 'TERM';
                 goto CLEANUP;
             }
         }
@@ -201,9 +206,10 @@ sub start_server {
     # cleanup
     $old_workers{$current_worker} = $ENV{SERVER_STARTER_GENERATION};
     undef $current_worker;
-    print STDERR "received $signals_received[0], sending TERM to all workers:",
+
+    print STDERR "received $signals_received[0], sending $term_signal to all workers:",
         join(',', sort keys %old_workers), "\n";
-    kill 'TERM', $_
+    kill $term_signal, $_
         for sort keys %old_workers;
     while (%old_workers) {
         if (my @r = wait3(1)) {

--- a/start_server
+++ b/start_server
@@ -20,7 +20,7 @@ GetOptions(
             $opts{$name} ||= undef;
             ref($opts{$name}) ? $opts{$name} : \$opts{$name};
         },
-    } qw(port=s path=s interval=i log-file=s pid-file=s signal-on-hup=s
+    } qw(port=s path=s interval=i log-file=s pid-file=s signal-on-hup=s signal-on-term=s
          status-file=s restart help version),
 ) or exit 1;
 pod2usage(
@@ -79,7 +79,11 @@ minimum interval to respawn the server program (default: 1)
 
 =head2 --signal-on-hup=SIGNAL
 
-name of the signal to be sent to the server process when start_server receives a SIGHUP (default: SIGTERM)
+name of the signal to be sent to the server process when start_server receives a SIGHUP (default: SIGTERM). If you use this option, be sure to also use C<--signal-on-term> below.
+
+=head2 --signal-on-term=SIGNAL
+
+name of the signal to be sent to the server process when start_server receives a SIGTERM (default: SIGTERM)
 
 =head2 --pid-file=filename
 


### PR DESCRIPTION
So that worker processes shutdown cleanly in INT/TERM.

I wonder if we should rename the options to eliminate `-on-hup` part, like `--signal-terminate`
