### PR TITLE
no overwrite pid-file if exist.

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -49,6 +49,15 @@ sub start_server {
     # open pid file
     my $pid_file_guard = sub {
         return unless $opts->{pid_file};
+        if(-e $opts->{pid_file}){
+            open my $fh, '<', $opts->{pid_file}
+                or die "failed to open file:$opts->{pid_file}: $!";
+            chomp(my $old_pid = <$fh>);
+            if(kill(0, $old_pid)){
+                croak "another Server::Starter is running. pid:$old_pid\n";
+            }
+            croak "pid files exists:$opts->{pid_file}\n";
+        }
         open my $fh, '>', $opts->{pid_file}
             or die "failed to open file:$opts->{pid_file}: $!";
         print $fh "$$\n";
@@ -59,6 +68,7 @@ sub start_server {
             },
         );
     }->();
+die "XXX";
     
     # open log file
     if ($opts->{log_file}) {

--- a/t/01-another-starter-is-running.t
+++ b/t/01-another-starter-is-running.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+use File::Temp ();
+use Test::More tests => 3;
+
+use Server::Starter qw(start_server);
+
+my($pid_fh, $pid_filename) = File::Temp::tempfile(UNLINK => 1);
+$pid_fh->autoflush;
+
+# make non exists pid
+my $old_pid = fork;
+exit unless($old_pid);
+waitpid($old_pid, 0);
+
+ok(! kill(0, $old_pid), 'make sure old pid does not exists');
+print $pid_fh $old_pid, "\n";
+
+eval {
+    start_server(path => '/dev/null', exec => [ '/dev/null' ], pid_file => $pid_filename);
+};
+like($@, qr/pid files exists/, 'pid files exists');
+
+seek($pid_fh, 0, 0);
+print $pid_fh $$, "\n";
+
+eval {
+    start_server(path => '/dev/null', exec => [ '/dev/null' ], pid_file => $pid_filename);
+};
+like($@, qr/another Server::Starter is running/, 'another Server::Starter is running');


### PR DESCRIPTION
If execute server-starter twice accidently, new process overwrite pid-file and remove it.
