### PR TITLE
fix chdir failure

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -285,7 +285,7 @@ sub _start_worker {
         if ($pid == 0) {
             my @args = @{$opts->{exec}};
             # child process
-            if ( exists $opts->{dir} ) {
+            if ( $opts->{dir} ) {
                 chdir $opts->{dir} or die "failed to chdir:$!";
             }
             { exec { $args[0] } @args };


### PR DESCRIPTION
$opts->{dir} is undef via start_server

./start_server line 20

```
        $opts{$name} ||= undef;
```
