### PR TITLE
daemonize

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -214,6 +214,25 @@ sub start_server {
         undef $logfh;
     }
 
+    # daemonize
+    if ($opts->{daemonize}) {
+        my $pid = fork;
+        die "fork failed:$!"
+            unless defined $pid;
+        if ($pid != 0) {
+            exit 0;
+        }
+        # in child process
+        POSIX::setsid();
+        $pid = fork;
+        die "fork failed:$!"
+            unless defined $pid;
+        if ($pid != 0) {
+            exit 0;
+        }
+        close STDIN;
+    }
+
     # setup the start_worker function
     my $start_worker = sub {
         my $pid;

--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -55,20 +55,6 @@ sub start_server {
     $ENV{AUTO_RESTART_INTERVAL} = $opts->{auto_restart_interval}
         if defined $opts->{auto_restart_interval};
 
-    # open pid file
-    my $pid_file_guard = sub {
-        return unless $opts->{pid_file};
-        open my $fh, '>', $opts->{pid_file}
-            or die "failed to open file:$opts->{pid_file}: $!";
-        print $fh "$$\n";
-        close $fh;
-        return Server::Starter::Guard->new(
-            sub {
-                unlink $opts->{pid_file};
-            },
-        );
-    }->();
-    
     # open log file
     my $logfh;
     if ($opts->{log_file}) {
@@ -232,6 +218,20 @@ sub start_server {
         }
         close STDIN;
     }
+
+    # open pid file
+    my $pid_file_guard = sub {
+        return unless $opts->{pid_file};
+        open my $fh, '>', $opts->{pid_file}
+            or die "failed to open file:$opts->{pid_file}: $!";
+        print $fh "$$\n";
+        close $fh;
+        return Server::Starter::Guard->new(
+            sub {
+                unlink $opts->{pid_file};
+            },
+        );
+    }->();
 
     # setup the start_worker function
     my $start_worker = sub {

--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -72,8 +72,15 @@ sub start_server {
     # open log file
     my $logfh;
     if ($opts->{log_file}) {
-        open $logfh, '>>', $opts->{log_file}
-            or die "failed to open log file:$opts->{log_file}: $!";
+        if ($opts->{log_file} =~ /^\s*\|\s*/s) {
+            my $cmd = $';
+            open $logfh, '|-', $cmd
+                or die "failed to open pipe:$opts->{log_file}: $!";
+        } else {
+            open $logfh, '>>', $opts->{log_file}
+                or die "failed to open log file:$opts->{log_file}: $!";
+        }
+        $logfh->autoflush(1);
     }
     
     # create guard that removes the status file
@@ -199,9 +206,9 @@ sub start_server {
     if ($logfh) {
         STDOUT->flush;
         STDERR->flush;
-        open STDOUT, '>&', $logfh
+        open STDOUT, '>&=', $logfh
             or die "failed to dup STDOUT to file: $!";
-        open STDERR, '>&', $logfh
+        open STDERR, '>&=', $logfh
             or die "failed to dup STDERR to file: $!";
         close $logfh;
         undef $logfh;

--- a/start_server
+++ b/start_server
@@ -21,7 +21,7 @@ GetOptions(
             ref($opts{$name}) ? $opts{$name} : \$opts{$name};
         },
     } qw(port=s path=s interval=i log-file=s pid-file=s dir=s signal-on-hup=s signal-on-term=s
-         backlog=i envdir=s enable-auto-restart=i auto-restart-interval=i kill-old-delay=i
+         backlog=i envdir=s enable-auto-restart=i daemonize auto-restart-interval=i kill-old-delay=i
          status-file=s restart help version),
 ) or exit 1;
 pod2usage(
@@ -36,6 +36,11 @@ if ($opts{version}) {
 if ($opts{restart}) {
     restart_server(%opts);
     exit 0;
+}
+
+if ($opts{daemonize}) {
+    die "Usage: --log-file option must be specified together with --deamonize\n"
+        unless defined $opts{log_file};
 }
 
 # validate options
@@ -113,6 +118,10 @@ This can be overwritten by environment variable C<ENVDIR>.
 
 if set, redirects STDOUT and STDERR to given file or command
 
+=head2 --daemonize
+
+deamonizes the server (by doing fork,setsid,fork).  Must be used together with C<--log-file>.
+
 =head2 --enable-auto-restart
 
 enables automatic restart by time.
@@ -128,13 +137,14 @@ This can be overwritten by environment variable C<AUTO_RESTART_INTERVAL>.
 time to suspend to send a signal to the old worker. The default value is 5 when C<--enable-auto-restart> is set, 0 otherwise.
 This can be overwritten by environment variable C<KILL_OLD_DELAY>.
 
+=head2 --backlog=size
+
+specifies a listen backlog parameter, whose default is SOMAXCONN (usually 128 on Linux). While SOMAXCONN is enough for most loads, large backlog is required for heavy loads.
+
 =head2 --restart
 
 this is a wrapper command that reads the pid of the start_server process from --pid-file, sends SIGHUP to the process and waits until the server(s) of the older generation(s) die by monitoring the contents of the --status-file
 
-=head2 --backlog
-
-specifies a listen backlog parameter, whose default is SOMAXCONN (usually 128 on Linux). While SOMAXCONN is enough for most loads, large backlog is required for heavy loads.
 
 =head2 --help
 

--- a/start_server
+++ b/start_server
@@ -107,6 +107,12 @@ directory that contains environment variables to the server processes.
 It is intended for use with C<envdir> in C<daemontools>.
 This can be overwritten by environment variable C<ENVDIR>.
 
+=head2 --log-file=file
+
+=head2 --log-file="| cmd args..."
+
+if set, redirects STDOUT and STDERR to given file or command
+
 =head2 --enable-auto-restart
 
 enables automatic restart by time.


### PR DESCRIPTION
This PR does three things:

* add `--daemonize` option that does double-`fork` and `setsid`
* accept pipe commands as the argument of `--log-file`
* rearrange the order of the setup tasks so that it would work nicely with daemonization

see also: #6