### PR TITLE
do not hard-code perl path to /usr/bin

### DIFF
--- a/start_server
+++ b/start_server
@@ -1,4 +1,6 @@
-#! /usr/bin/perl
+#! /bin/sh
+exec perl -x $0 "$@"
+#! perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
Does same thing as https://github.com/h2o/h2o/commit/9e1ce96cdf199e6d2bf85094f526b7ef6047fe51, fixes https://github.com/h2o/h2o/issues/288.