### PR TITLE
use #!perl so that it will be rewritten by MakeMaker.

### DIFF
--- a/start_server
+++ b/start_server
@@ -1,6 +1,4 @@
-#! /bin/sh
-exec perl -x $0 "$@"
-#! perl
+#!perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
This reverts #21 and lets MakeMaker rewrite the shebang appropriately.

```
➜  p5-Server-Starter git:(shebang) ✗ perl Makefile.PL
include /Users/miyagawa/dev/p5-Server-Starter/inc/Module/Install.pm
include inc/Module/Install/Metadata.pm
include inc/Module/Install/Base.pm
include inc/Module/Install/Makefile.pm
include inc/Module/Install/Include.pm
include inc/Test/Requires.pm
include inc/IO/Socket/IP.pm
include inc/Net/EmptyPort.pm
include inc/Test/SharedFork.pm
include inc/Test/TCP.pm
include inc/Module/Install/AutoInstall.pm
include inc/Module/AutoInstall.pm
include inc/Module/Install/Repository.pm
Cannot deduce auto_provides without a MANIFEST, skipping
include inc/Module/Install/Scripts.pm
include inc/Module/Install/WriteAll.pm
include inc/Module/Install/Win32.pm
include inc/Module/Install/Can.pm
include inc/Module/Install/Fetch.pm
Generating a Unix-style Makefile
Writing Makefile for Server::Starter
Writing MYMETA.yml and MYMETA.json
Writing META.yml

➜  p5-Server-Starter git:(shebang) ✗ make
cp start_server.fatpacked.pl blib/lib/Server/start_server.fatpacked.pl
cp lib/Server/Starter/Guard.pm blib/lib/Server/Starter/Guard.pm
cp lib/Server/Starter.pm blib/lib/Server/Starter.pm
cp start_server blib/script/start_server
"/Users/miyagawa/.plenv/versions/5.20.1/bin/perl5.20.1" "-Iinc" -MExtUtils::MY -e 'MY->fixin(shift)' -- blib/script/start_server
Manifying 1 pod document
Manifying 2 pod documents

➜  p5-Server-Starter git:(shebang) ✗ head blib/script/start_server
#!/Users/miyagawa/.plenv/versions/5.20.1/bin/perl5.20.1

use strict;
use warnings;

use Getopt::Long;
use Pod::Usage;
use Server::Starter qw(start_server restart_server);

my %opts = (
```