### PR TITLE
Added file descriptor duplication feature.

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -85,13 +85,13 @@ sub start_server {
         my ($domain, $sa);
         my $fd;
         my $sockopts = sub {};
-        if ($hostport =~ /^\s*(\d+)(?:\s*:(\d+))?\s*$/) {
+        if ($hostport =~ /^\s*(\d+)(?:\s*=(\d+))?\s*$/) {
             # by default, only bind to IPv4 (for compatibility)
             $hostport = $1;
             $fd = $2;
             $domain = Socket::PF_INET;
             $sa = pack_sockaddr_in $1, Socket::inet_aton("0.0.0.0");
-        } elsif ($hostport =~ /^\s*(?:\[\s*|)([^\]]*)\s*(?:\]\s*|):\s*(\d+)(?:\s*:(\d+))?\s*$/) {
+        } elsif ($hostport =~ /^\s*(?:\[\s*|)([^\]]*)\s*(?:\]\s*|):\s*(\d+)(?:\s*=(\d+))?\s*$/) {
             my ($host, $port) = ($1, $2);
             $fd = $3;
             if ($host =~ /:/) {

--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -139,8 +139,11 @@ sub start_server {
             POSIX::dup2($sock->fileno, $fd)
                 or die "dup2(2) failed(${fd}): $!";
             print STDERR "socket is duplicated to file descriptor ${fd}\n";
+            close $sock;
+            push @sockenv, "$hostport=$fd";
+        } else {
+            push @sockenv, "$hostport=" . $sock->fileno;
         }
-        push @sockenv, "$hostport=" . $sock->fileno;
         push @sock, $sock;
     }
     my $path_remove_guard = Server::Starter::Guard->new(

--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -83,14 +83,17 @@ sub start_server {
     my @sockenv;
     for my $hostport (@$ports) {
         my ($domain, $sa);
+        my $fd;
         my $sockopts = sub {};
-        if ($hostport =~ /^\s*(\d+)\s*$/) {
+        if ($hostport =~ /^\s*(\d+)(?:\s*:(\d+))?\s*$/) {
             # by default, only bind to IPv4 (for compatibility)
             $hostport = $1;
+            $fd = $2;
             $domain = Socket::PF_INET;
             $sa = pack_sockaddr_in $1, Socket::inet_aton("0.0.0.0");
-        } elsif ($hostport =~ /^\s*(?:\[\s*|)([^\]]*)\s*(?:\]\s*|):\s*(\d+)\s*$/) {
+        } elsif ($hostport =~ /^\s*(?:\[\s*|)([^\]]*)\s*(?:\]\s*|):\s*(\d+)(?:\s*:(\d+))?\s*$/) {
             my ($host, $port) = ($1, $2);
+            $fd = $3;
             if ($host =~ /:/) {
                 # IPv6
                 local $@;
@@ -132,6 +135,11 @@ sub start_server {
             or die "listen(2) failed:$!";
         fcntl($sock, F_SETFD, my $flags = '')
                 or die "fcntl(F_SETFD, 0) failed:$!";
+        if (defined $fd) {
+            POSIX::dup2($sock->fileno, $fd)
+                or die "dup2(2) failed(${fd}): $!";
+            print STDERR "socket is duplicated to file descriptor ${fd}\n";
+        }
         push @sockenv, "$hostport=" . $sock->fileno;
         push @sock, $sock;
     }

--- a/script/start_server
+++ b/script/start_server
@@ -71,7 +71,7 @@ This script is a frontend of L<Server::Starter>.  For more information please re
 
 =head1 OPTIONS
 
-=head2 --port=(port|host:port|port:fd|host:port:fd)
+=head2 --port=(port|host:port|port=fd|host:port=fd)
 
 TCP port to listen to (if omitted, will not bind to any ports)
 

--- a/script/start_server
+++ b/script/start_server
@@ -71,12 +71,14 @@ This script is a frontend of L<Server::Starter>.  For more information please re
 
 =head1 OPTIONS
 
-=head2 --port=(port|host:port)
+=head2 --port=(port|host:port|port:fd|host:port:fd)
 
 TCP port to listen to (if omitted, will not bind to any ports)
 
 If host is not specified, then the program will bind to the default address of IPv4 ("0.0.0.0").
 Square brackets should be used to specify an IPv6 address (e.g. --port=[::1]:8080)
+
+If fd is specified, then start_server duplicates socket file descriptor to fd.
 
 =head2 --path=path
 

--- a/t/11-specified-fd-server.pl
+++ b/t/11-specified-fd-server.pl
@@ -5,8 +5,9 @@ use warnings;
 use lib qw(blib/lib lib);
 
 use IO::Socket::INET;
+use Server::Starter qw(server_ports);
 
-warn "STARTED $$";
+die "fd must be zero" unless ((values %{server_ports()})[0]) eq 0;
 
 my $listener = IO::Socket::INET->new(
     Proto => 'tcp',

--- a/t/11-specified-fd-server.pl
+++ b/t/11-specified-fd-server.pl
@@ -1,0 +1,24 @@
+#! /usr/bin/perl
+use strict;
+use warnings;
+
+use lib qw(blib/lib lib);
+
+use IO::Socket::INET;
+
+warn "STARTED $$";
+
+my $listener = IO::Socket::INET->new(
+    Proto => 'tcp',
+);
+$listener->fdopen(0, 'w')
+    or die "failed to bind listening socket:$!";
+
+while (1) {
+    if (my $conn = $listener->accept) {
+        my $buf;
+        while ($conn->sysread($buf, 1048576) > 0) {
+            $conn->syswrite("$$:$buf");
+        }
+    }
+}

--- a/t/11-specified-fd.t
+++ b/t/11-specified-fd.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use File::Temp ();
+use Test::TCP;
+use Test::More tests => 4;
+
+use Server::Starter qw(start_server);
+
+$SIG{PIPE} = sub {};
+
+test_tcp(
+    server => sub {
+        my $port = shift;
+        start_server(
+            port        => "$port:0",
+            exec        => [
+                $^X, qw(t/11-specified-fd-server.pl)
+            ],
+        );
+        exit 0;
+    },
+    client => sub {
+        my ($port, $server_pid) = @_;
+        my $buf;
+        #sleep 1;
+        my $sock = IO::Socket::INET->new(
+            PeerAddr => "127.0.0.1:$port",
+            Proto    => 'tcp',
+        );
+        ok($sock, 'connect');
+        # check response and get pid
+        is($sock->syswrite("hello"), 5, 'write');
+        ok($sock->sysread($buf, 1048576), 'read');
+        undef $sock;
+        like($buf, qr/^\d+:hello$/, 'read');
+        kill $server_pid;
+    },
+);
+

--- a/t/11-specified-fd.t
+++ b/t/11-specified-fd.t
@@ -13,7 +13,7 @@ test_tcp(
     server => sub {
         my $port = shift;
         start_server(
-            port        => "$port:0",
+            port        => "$port=0",
             exec        => [
                 $^X, qw(t/11-specified-fd-server.pl)
             ],


### PR DESCRIPTION
Use case:
  * JVM can use file descriptor 0 as a server port.
  * User can use Server::Starter without parsing ENV[SERVER_STARTER_PORT]