### PR TITLE
Reopen STDIN after close.

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -231,6 +231,8 @@ sub start_server {
         # do not close STDIN if `--port=n=0`.
         unless (grep /=0$/, @sockenv) {
             close STDIN;
+            open STDIN, '<', '/dev/null'
+                or die "reopen failed: $!";
         }
     }
 


### PR DESCRIPTION
To suppress 'Filehandle STDIN reopened as $fh only for output' warning.