### PR TITLE
fixes issue #34: socket file shouldn't be removed when it daemonises

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -150,12 +150,6 @@ sub start_server {
         }
         push @sock, $sock;
     }
-    my $path_remove_guard = Server::Starter::Guard->new(
-        sub {
-            -S $_ and unlink $_
-                for @$paths;
-        },
-    );
     for my $path (@$paths) {
         if (-S $path) {
             warn "removing existing socket file:$path";
@@ -240,6 +234,13 @@ sub start_server {
                 or die "reopen failed: $!";
         }
     }
+
+    my $path_remove_guard = Server::Starter::Guard->new(
+        sub {
+            -S $_ and unlink $_
+                for @$paths;
+        },
+    );
 
     # open pid file
     my $pid_file_guard = sub {

--- a/lib/Server/Starter/Guard.pm
+++ b/lib/Server/Starter/Guard.pm
@@ -5,12 +5,17 @@ use warnings;
 
 sub new {
     my ($klass, $handler) = @_;
-    return bless [ $handler ], $klass;
+    return bless {
+       handler => $handler,
+       active  => 1,
+   }, $klass;
 }
+
+sub dismiss { shift->{active} = 0 }
 
 sub DESTROY {
     my $self = shift;
-    $self->[0]->();
+    $self->{active} && $self->{handler}->();
 }
 
 1;

--- a/t/09-guard.t
+++ b/t/09-guard.t
@@ -4,14 +4,28 @@ use Test::More;
 
 use_ok("Server::Starter::Guard");
 
-my $cnt = 0;
+subtest "guard is called when it goes out of scope" => sub {
+    my $cnt = 0;
 
-my $guard = Server::Starter::Guard->new(sub {
-    $cnt++;
-});
+    my $guard = Server::Starter::Guard->new(sub {
+        $cnt++;
+    });
 
-is $cnt, 0;
-undef $guard;
-is $cnt, 1;
+    is $cnt, 0;
+    undef $guard;
+    is $cnt, 1;
+};
+
+subtest "guard can be dismissed" => sub {
+    my $cnt = 0;
+
+    my $guard = Server::Starter::Guard->new(sub {
+        $cnt++;
+    });
+
+    $guard->dismiss;
+    undef $guard;
+    is $cnt, 0;
+};
 
 done_testing;

--- a/t/13-unix-daemonize.t
+++ b/t/13-unix-daemonize.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Server::Starter qw(start_server stop_server);
+use Server::Starter::Guard;
+use File::Temp qw(tempdir);
+
+plan tests => 1;
+
+my $dir = tempdir( CLEANUP => 1 );
+my $pidfile  = "$dir/pid";
+my $sockfile = "$dir/server.sock";
+
+fork_ok(
+    child => sub {
+        start_server(
+            pid_file  => $pidfile,
+            daemonize => 1,
+            path      => $sockfile,
+            exec      => [ $^X, qw(t/03-starter-unix-echod.pl) ],
+        );
+    },
+
+    parent => sub {
+        my $guard = Server::Starter::Guard->new(sub {
+            stop_server( pid_file => $pidfile );
+        });
+
+        wait_for(sub { -e $pidfile })
+            or BAIL_OUT("Pidfile '$pidfile' was not created in a timely fashion");
+
+        wait_for(sub { -e $sockfile })
+            or BAIL_OUT("Socket '$sockfile' was not created in a timely fashion");
+
+        ok(-e $sockfile, 'there is a socket');
+    },
+) or die "fork failed: $!";
+
+sub fork_ok {
+    my (%args) = @_;
+
+    my $pid = fork;
+    return unless defined $pid;
+    if ($pid == 0) {
+        $args{child}->();
+    }
+    else {
+        $args{parent}->($pid);
+    }
+
+    return 1;
+}
+
+sub wait_for {
+    my ($code, %opts) = @_;
+
+    my $times = $opts{times} || 10;
+    my $every = $opts{every} || 1;
+
+    while ( $times > 0 ) {
+        return 1 if $code->();
+        $times--;
+        sleep $every;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
For issue #34, create the scope guard that removes socket files after Server::Starter daemonises otherwise they are removed when the original process exits