### PR TITLE
Fix for Solaris

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -456,7 +456,7 @@ sub stop_server {
         unless $opts->{pid_file};
 
     # get pid
-    open my $fh, '<', $opts->{pid_file}
+    open my $fh, '+<', $opts->{pid_file}
         or die "failed to open file:$opts->{pid_file}:$!";
     my $pid = do {
         my $line = <$fh>;


### PR DESCRIPTION
Exclusive lock on Solaris requires write permission. And platforms where `flock` are emulated require write intent for exclusive lock.

`perldoc -f flock` says as below.

> Note that the fcntl(2) emulation of flock(3) requires that
> FILEHANDLE be open with read intent to use LOCK_SH and requires
> that it be open with write intent to use LOCK_EX

See also
- http://www.nntp.perl.org/group/perl.perl5.porters/2006/01/msg108851.html
