### PR TITLE
--enable-auto-restart is an argument-less switch

### DIFF
--- a/script/start_server
+++ b/script/start_server
@@ -21,7 +21,7 @@ GetOptions(
             ref($opts{$name}) ? $opts{$name} : \$opts{$name};
         },
     } qw(port=s path=s interval=i log-file=s pid-file=s dir=s signal-on-hup=s signal-on-term=s
-         backlog=i envdir=s enable-auto-restart=i daemonize auto-restart-interval=i kill-old-delay=i
+         backlog=i envdir=s enable-auto-restart daemonize auto-restart-interval=i kill-old-delay=i
          status-file=s restart stop help version),
 ) or exit 1;
 pod2usage(


### PR DESCRIPTION
Using `--enable-auto-restart=1` is not intuitive, and it's also not documented.