### PR TITLE
fix: ensure sleep KILL_OLD_DELAY

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -390,7 +390,7 @@ sub start_server {
             if ($kill_old_delay != 0) {
                 print STDERR "sleeping $kill_old_delay secs before killing old workers\n";
                 while ($kill_old_delay > 0) {
-                    $kill_old_delay -= sleep $kill_old_delay;
+                    $kill_old_delay -= sleep $kill_old_delay || 1;
                 }
             }
             print STDERR "killing old workers\n";

--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -389,7 +389,9 @@ sub start_server {
             my $kill_old_delay = defined $ENV{KILL_OLD_DELAY} ? $ENV{KILL_OLD_DELAY} : $ENV{ENABLE_AUTO_RESTART} ? 5 : 0;
             if ($kill_old_delay != 0) {
                 print STDERR "sleeping $kill_old_delay secs before killing old workers\n";
-                sleep $kill_old_delay;
+                while ($kill_old_delay > 0) {
+                    $kill_old_delay -= sleep $kill_old_delay;
+                }
             }
             print STDERR "killing old workers\n";
             kill $opts->{signal_on_hup}, $_


### PR DESCRIPTION
@kazuho 

As we discussed in https://github.com/kazuho/p5-Server-Starter/issues/44, I have tried to fix the sleep in `KILL_OLD_DELAY` interrupted by a signal right after the previous one. The old workers will now keep alive before new workers get ready.

Please take a look.

I would appreciate it if you could change the minor version number for this fix.
Thanks.