### PR TITLE
Fix building on Perl without "." in @INC

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 use utf8;
 
+BEGIN { push @INC, '.'; }
 use builder::MyBuilder;
 use File::Basename;
 use File::Spec;


### PR DESCRIPTION
This fixes building on Perl 5.26.0.