### PR TITLE
make start_server able to work without any specific ports/path

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -37,8 +37,6 @@ sub start_server {
     # prepare args
     my $ports = $opts->{port};
     my $paths = $opts->{path};
-    croak "either of ``port'' or ``path'' option is mandatory\n"
-        unless $ports || $paths;
     $ports = [ $ports ]
         if ! ref $ports && defined $ports;
     $paths = [ $paths ]
@@ -480,7 +478,7 @@ sub stop_server {
 
 sub server_ports {
     die "no environment variable SERVER_STARTER_PORT. Did you start the process using server_starter?",
-        unless $ENV{SERVER_STARTER_PORT};
+        unless defined $ENV{SERVER_STARTER_PORT};
     my %ports = map {
         +(split /=/, $_, 2)
     } split /;/, $ENV{SERVER_STARTER_PORT};

--- a/t/14-without-port-env.pl
+++ b/t/14-without-port-env.pl
@@ -1,0 +1,25 @@
+#! /usr/bin/perl
+use strict;
+use warnings;
+
+use lib qw(blib/lib lib);
+
+use Server::Starter qw(server_ports);
+
+my $fn = shift @ARGV;
+open my $fh, '>', $fn
+    or die "could not open file:$fn:$!";
+
+my $env = $ENV{SERVER_STARTER_PORT};
+my $server_ports = server_ports();
+print $fh 'env: ' . (defined $env ? 'found' : 'not found') . "\n";
+print $fh 'server_ports: ' . (%$server_ports ? 'not empty' : 'empty') . "\n";
+
+$SIG{TERM} = $SIG{USR1} = sub {
+    exit 0;
+};
+
+
+while (1) {
+    sleep 1;
+}

--- a/t/14-without-port.t
+++ b/t/14-without-port.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use File::Temp ();
+use Test::More tests => 2;
+
+use Server::Starter qw(start_server);
+
+$SIG{PIPE} = sub {};
+
+my $tempdir = File::Temp::tempdir(CLEANUP => 1);
+
+my $pid = fork;
+unless ($pid) {
+    start_server(
+        exec => [
+            $^X, qw(t/14-without-port-env.pl), "$tempdir/env",
+        ],
+    );
+    exit 0;
+};
+sleep 1;
+kill 'TERM', $pid;
+sleep 1;
+
+open my $fh, '<', "$tempdir/env"
+    or die "failed to open file:$tempdir/env:$!";
+my $log = do { undef $/; <$fh> };
+like $log, qr/^env: found$/m;
+like $log, qr/^server_ports: empty$/m;


### PR DESCRIPTION
There are some use cases that we don't want `start_server` to listen and bind any sockets, e.g.  the server program do it by itself with SO_REUSEPORT option. Even in such case, start_server is useful for restarting the programs..
After this PR, if the user doesn't specify any`port` and `path` options, `SERVER_STARTER_PORT` env will exist but be an empty string, and `Server::Starter#server_ports` returns an empty hash reference. In such case, server programs should handle it (for instance, open the sockets by themselves).