### PR TITLE
Load env even for the first worker and master

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -56,6 +56,10 @@ sub start_server {
     $ENV{AUTO_RESTART_INTERVAL} = $opts->{auto_restart_interval}
         if defined $opts->{auto_restart_interval};
 
+    my %loaded_env = _load_env();
+    my @loaded_env_keys = keys %loaded_env;
+    local @ENV{@loaded_env_keys} = map { $loaded_env{$_} } (@loaded_env_keys);
+
     # open log file
     my $logfh;
     if ($opts->{log_file}) {
@@ -334,7 +338,7 @@ sub start_server {
         # wait for next signal (or when auto-restart becomes necessary)
         my @r = $wait->();
         # reload env if necessary
-        my %loaded_env = _reload_env();
+        my %loaded_env = _load_env();
         my @loaded_env_keys = keys %loaded_env;
         local @ENV{@loaded_env_keys} = map { $loaded_env{$_} } (@loaded_env_keys);
         $ENV{AUTO_RESTART_INTERVAL} ||= 360
@@ -487,7 +491,7 @@ sub server_ports {
     \%ports;
 }
 
-sub _reload_env {
+sub _load_env {
     my $dn = $ENV{ENVDIR};
     return if !defined $dn or !-d $dn;
     my $d;

--- a/script/start_server
+++ b/script/start_server
@@ -115,8 +115,8 @@ if set, writes the status of the server process(es) to the file
 
 =head2 --envdir=ENVDIR
 
-directory that contains environment variables to the server processes.
-It is intended for use with C<envdir> in C<daemontools>.
+directory that contains environment variables to the server processes and superdaemon.
+It is inspired by C<envdir> in C<daemontools>.
 This can be overwritten by environment variable C<ENVDIR>.
 
 =head2 --log-file=file

--- a/t/07-envdir.t
+++ b/t/07-envdir.t
@@ -50,9 +50,9 @@ test_tcp(
             kill "HUP", $server_pid;
             sleep 2;
         };
-        # Initial worker does not read envdir
+        # Initial worker does read envdir
         my $buf = $fetch_env->();
-        ok($buf !~ qr/^FOO=foo-value1$/m, 'changed env');
+        ok($buf =~ qr/^FOO=foo-value1$/m, 'changed env');
         # rewrite envdir
         open my $envfh, ">", "$tempdir/env/FOO" or die $!;
         print $envfh "foo-value2";


### PR DESCRIPTION
@kazuho @limitus

## Summary

This patch let `--envdir` load environment variables even for the first worker,
including Server::Starter itself.

This closes #50 

## Reason why we need to load environment variables even for Server::Starter itself.

The reason why loading environment variables for the first worker is required is described in #50.
Here, I would like to address the reason why we need to load environment variables even for the Server::Starter.

Mainly, this is for backward-compatibility.
At first glance, current implementation using `local` in `while(1)` seems to try not to affect the behavior of `Server::Starter` itself. However, since we reference environment variables directly, `ENABLE_AUTO_RESTART`,  `AUTO_RESTART_INTERVAL`, and other environment are actually under the effect of `envdir` after the first restart or signal.

IMHO, I think it is the best option to load the environment variables right after setting environment variables from options and let it take effect for `Server::Starter`. This can further reduce the gap before and after the first restart.

The only exception now is the `ENABLE_AUTO_RESTART` below.

https://github.com/aeroastro/p5-Server-Starter/blob/4558fa31a514854d58b5ca0e0d28d843d6ea195a/lib/Server/Starter.pm#L300-L312

If we want strict design, I will add another `_load_env` before `$wait->()`