### PR TITLE
Use 0 instead of empty string for fcntl(F_SETFD) arg

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -145,7 +145,7 @@ sub start_server {
             listen $sock, $opts->{backlog}
                 or die "listen(2) failed:$!";
         }
-        fcntl($sock, F_SETFD, my $flags = '')
+        fcntl($sock, F_SETFD, 0)
                 or die "fcntl(F_SETFD, 0) failed:$!";
         if (defined $fd) {
             POSIX::dup2($sock->fileno, $fd)
@@ -177,7 +177,7 @@ sub start_server {
             Local  => $path,
         ) or die "failed to listen to file $path:$!";
         umask($saved_umask);
-        fcntl($sock, F_SETFD, my $flags = '')
+        fcntl($sock, F_SETFD, 0)
             or die "fcntl(F_SETFD, 0) failed:$!";
         push @sockenv, "$path=" . $sock->fileno;
         push @sock, $sock;


### PR DESCRIPTION
Passing empty string as fcntl arg then Perl passes pointer value to Kernel.
Almost all Unix like system of fcntl(F_SETFD) implementation only checks
that LSB is 0 or 1 by (arg & FD_CLOEXEC) and there is no problems for clearing
flags because LSB of pointer value always is 0. However some implementation
like WSL (Windows Subsystem for Linux) checks arg value and return EINVAL
if it is invalid valid.

This is related to https://github.com/h2o/h2o/issues/2146

#### check argument by `strace` on Linux

```perl
#!/usr/bin/env perl
use strict;
use warnings;

use Socket;
use Fcntl;

socket(my $sock, PF_INET, SOCK_STREAM, getprotobyname('tcp'));
setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, 1);
fcntl($sock, F_SETFD, my $flags='') or die "failed fcntl: $!";
close $sock;
```

Check this script behavior with `strace`

```
sudo strace -e trace=fcntl perl test.pl
[sudo] password for syohei:
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(0, F_SETFD, 0)                    = 0
fcntl(1, F_SETFD, 0)                    = 0
fcntl(2, F_SETFD, 0)                    = 0
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
fcntl(3, F_SETFD, 0x9c922de0 /* FD_??? */) = 0 # <- Passing pointer value
```

#### WSL behavior

```perl
#!/usr/bin/env perl
use strict;
use warnings;

use Socket;
use Fcntl;

socket(my $sock, PF_INET, SOCK_STREAM, getprotobyname('tcp'));
setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, 1);
fcntl($sock, F_SETFD, 0) or warn "failed fcntl(0): $!";
fcntl($sock, F_SETFD, 1) or warn "failed fcntl(1): $!";
fcntl($sock, F_SETFD, 2) or warn "failed fcntl(2): $!";
close $sock;
exit 0;
```

##### Check behavior by `strace` on WSL

```
sudo strace -e trace=fcntl perl test.pl
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(0, F_SETFD, 0)                    = 0
fcntl(1, F_SETFD, 0)                    = 0
fcntl(2, F_SETFD, 0)                    = 0
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
fcntl(3, F_SETFD, 0)                    = 0
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
fcntl(3, F_SETFD, 0x2 /* FD_??? */)     = -1 EINVAL (Invalid argument)
```

It looks WSL `fcntl(SET_FD)` implementation only accepts `0` or `1`.

#### Reference

##### Linux implementation

https://github.com/torvalds/linux/blob/0a68ff5e2e7cf2263674b7f0418b31e10b2a497f/fs/fcntl.c#L339-L342

```c
	case F_SETFD:
		err = 0;
		set_close_on_exec(fd, arg & FD_CLOEXEC);
		break;
```

##### FreeBSD implementation

https://github.com/freebsd/freebsd/blob/e75280f8644acdaa030b14dbf02b49d5d089fe66/sys/kern/kern_descrip.c#L525-L535

```c
	case F_SETFD:
		error = EBADF;
		FILEDESC_XLOCK(fdp);
		fde = fdeget_locked(fdp, fd);
		if (fde != NULL) {
			fde->fde_flags = (fde->fde_flags & ~UF_EXCLOSE) |
			    (arg & FD_CLOEXEC ? UF_EXCLOSE : 0);
			error = 0;
		}
		FILEDESC_XUNLOCK(fdp);
		break;
```

