### PR TITLE
Allow :ssl prefix in --listen addresses

### DIFF
--- a/lib/Server/Starter.pm
+++ b/lib/Server/Starter.pm
@@ -92,6 +92,7 @@ sub start_server {
         my $socktype = Socket::SOCK_STREAM();
         my $fd;
         my $sockopts = sub {};
+        my $ssl = $hostport =~ s/:ssl\b//;
         if ($hostport =~ /^\s*(u?)(\d+)(?:\s*=(\d+))?\s*$/) {
             # by default, only bind to IPv4 (for compatibility)
             ($hostport, $fd) = ($2, $3);
@@ -154,6 +155,9 @@ sub start_server {
             close $sock;
             push @sockenv, "$hostport=$fd";
         } else {
+            if ($ssl) {
+                $hostport = "$hostport:ssl";
+            }
             push @sockenv, "$hostport=" . $sock->fileno;
         }
         push @sock, $sock;


### PR DESCRIPTION
This goes along with a PR in p5-Net-Server-SS-PreFork that would allow start_server to require SSL on specific connections the same way starman does, like this:

    --listen 1.1.1.1:1111:ssl
    --listen 2.2.2.2:2222
    --listen 3.3.3.3:3333:ssl